### PR TITLE
Add default PR template

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,12 @@
+# Related Tickets
+<!--- (Optional) Please include links to any JIRA tickets related to this PR -->
+
+# Description
+<!-- Please describe in your own words what this PR is intended to do -->
+
+# Validation
+<!-- How should a reviewer with limited context be able to prove this change 'does what it says on the tin'? -->
+<!-- Please include any type of expected results whether screenshots or output to compare. -->
+
+# Risks
+<!-- Are there any considerations at all regarding possible regressions, dependencies, build, rollout, etc -->


### PR DESCRIPTION
# Related Tickets
<!--- (Optional) Please include links to any JIRA tickets related to this PR -->
N/A

# Description
<!-- Please describe in your own words what this PR is intended to do -->
This introduces a default PR template which should automatically apply to some of our repos (at least public repos, but possibly all repos that do not provide their own template file). https://docs.github.com/en/free-pro-team@latest/github/building-a-strong-community/creating-a-default-community-health-file If this does not automatically apply, this can also serve as a source of truth for copying to repos without a PR template.

# Validation
<!-- How should a reviewer with limited context be able to prove this change 'does what it says on the tin'? -->
<!-- Please include any type of expected results whether screenshots or output to compare. -->
I have copied the format in to this PR manually, as it is not yet on the main branch it did not automatically apply. Testing the automatic application will have to be done after the fact, but debating the merit of this format can be done directly on this PR.

# Risks
<!-- Are there any considerations at all regarding possible regressions, dependencies, build, rollout, etc -->
There are no risks here, other than possibly creating noise in repos if developers are not aware of the expectation to fill out a PR template with a PR submission.